### PR TITLE
Allow only http(s)

### DIFF
--- a/backend/src/models/Link.ts
+++ b/backend/src/models/Link.ts
@@ -9,5 +9,5 @@ export interface Link {
 
 export const linkSchema = Joi.object({
     shortenUrl: Joi.string().pattern(/^[a-z_\-]+$/).optional(),
-    originalUrl: Joi.string().required(),
+    originalUrl: Joi.string().pattern(/^(http|https):\/\//).required(),
 });


### PR DESCRIPTION
Added regex validation for url. String should either start with `http` or `https`.