### PR TITLE
Enhancements to `/api/v1/auth/signup` endpoint

### DIFF
--- a/backend/src/models/Account.ts
+++ b/backend/src/models/Account.ts
@@ -2,12 +2,21 @@ import { ObjectId } from "mongodb";
 import Joi from "joi";
 
 export interface Account {
+    firstName: string;
+    lastName: string;
     username: string;
     password: string;
     _id?: ObjectId;
 }
 
 export const accountSchema = Joi.object({
+    firstName: Joi.string().min(2).required(),
+    lastName: Joi.string().min(2).required(),
+    username: Joi.string().min(5).required(),
+    password: Joi.string().min(8).required(),
+});
+
+export const loginSchema = Joi.object({
     username: Joi.string().min(5).required(),
     password: Joi.string().min(8).required(),
 });

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -48,7 +48,12 @@ authRouter.post("/signup", async (req: Request, res: Response) => {
         );
 
         if (result.acknowledged) {
-            res.status(201).send({ message: "Account created successfully!" });
+            let userPayload: UserPayload = {
+                id: result.insertedId.toString(),
+                username: account.username
+            }
+            let authToken = generateJwt(userPayload)
+            res.status(201).send({ message: authToken });
         } else {
             res.status(500).send({ message: "Failed to create shorten link" });
         }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response, Router } from "express";
 import { hashPassword } from "../utils/hash-password";
 import { collections } from "../services/database";
-import { accountSchema } from "../models/Account";
+import { accountSchema, loginSchema } from "../models/Account";
 import { Account } from "../models/Account";
 import { UserPayload, generateJwt } from "../utils/jwt-provider";
 
@@ -40,6 +40,8 @@ authRouter.post("/signup", async (req: Request, res: Response) => {
 
         const result = await collections.accounts.insertOne(
             {
+                firstName: account.firstName,
+                lastName: account.lastName,
                 username: account.username,
                 password: hashedPassword
             }
@@ -66,7 +68,7 @@ authRouter.post("/signup", async (req: Request, res: Response) => {
 */
 authRouter.post("/login", async (req: Request, res: Response) => {
     try {
-        const { error } = accountSchema.validate(req.body);
+        const { error } = loginSchema.validate(req.body);
         if (error) {
             res.status(400).send({ message: "Invalid account body" });
             return;


### PR DESCRIPTION
## Enhancements to /api/v1/auth/signup endpoint

- `firstName` and `lastName` fields are now **required** in the post body for account creation.
- **A JWT token is now returned** after successful account creation, eliminating the need for a separate login after signup.