### PR TITLE
Implement Dashboard Page for Shortened Links

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.11",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "bootstrap-icons": "^1.10.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.7.0",
@@ -5133,6 +5134,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.4.tgz",
+      "integrity": "sha512-eI3HyIUmpGKRiRv15FCZccV+2sreGE2NnmH8mtxV/nPOzQVu0sPEj8HhF1MwjJ31IhjF0rgMvtYOX5VqIzcb/A=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1",
+        "react-toastify": "^9.1.2",
         "reactstrap": "^9.1.5",
         "typescript": "^4.9.4",
         "web-vitals": "^2.1.4"
@@ -5428,6 +5429,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14143,6 +14152,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.2.tgz",
+      "integrity": "sha512-PBfzXO5jMGEtdYR5jxrORlNZZe/EuOkwvwKijMatsZZm8IZwLj01YvobeJYNjFcA6uy6CVrx2fzL9GWbhWPTDA==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.11",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "bootstrap-icons": "^1.10.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.2",
     "reactstrap": "^9.1.5",
     "typescript": "^4.9.4",
     "web-vitals": "^2.1.4"

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,6 +8,7 @@
   <meta name="description" content="Shorten website links" />
   <title>ShrinkMe</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" />
 </head>
 
 <body>

--- a/frontend/src/components/AuthPage.css
+++ b/frontend/src/components/AuthPage.css
@@ -252,7 +252,7 @@ input[type="radio"] {
 
 .modal-content {
     border-radius: 16px;
-    background-color: #121212;
+    background-color: #181818;
     color: #f9fafc;
 }
 

--- a/frontend/src/components/DashPage.css
+++ b/frontend/src/components/DashPage.css
@@ -1,0 +1,44 @@
+.dash-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    height: 100%;
+    width: 100%;
+    transition: all 0.6s ease;
+}
+
+.dash-heading {
+    position: sticky;
+    top: 0;
+    background-color: #121212;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-bottom: 0;
+    width: 100%;
+    z-index: 1;
+}
+
+.links-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-rows: repeat(3, 1fr);
+    grid-gap: 20px;
+    width: 90vw;
+    margin-top: 20px;
+    margin-bottom: 24px;
+}
+
+@media (max-width: 600px) {
+    .links-grid {
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        grid-template-rows: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 400px) {
+    .links-grid {
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        grid-template-rows: repeat(1, 1fr);
+    }
+}

--- a/frontend/src/components/DashPage.css
+++ b/frontend/src/components/DashPage.css
@@ -42,3 +42,9 @@
         grid-template-rows: repeat(1, 1fr);
     }
 }
+
+
+.no-background {
+    background: none;
+    border: none;
+}

--- a/frontend/src/components/DashPage.tsx
+++ b/frontend/src/components/DashPage.tsx
@@ -1,0 +1,17 @@
+import { useContext, useEffect } from "react"
+import { AuthContext } from "../containers/App"
+
+export default function DashPage() {
+    const { isLoggedIn } = useContext(AuthContext);
+
+    useEffect(() => {
+        if (!isLoggedIn) {
+            window.location.href = "/";
+        }
+    }, [isLoggedIn])
+
+    return (
+        <div className="dash-page">
+        </div>
+    )
+}

--- a/frontend/src/components/DashPage.tsx
+++ b/frontend/src/components/DashPage.tsx
@@ -10,7 +10,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import "./DashPage.css"
 
 interface UserLink {
-    id: string,
+    _id: string
     shortenUrl: string,
     originalUrl: string,
 }
@@ -63,6 +63,46 @@ export default function DashPage() {
 
     }, [isLoggedIn]);
 
+    const deleteLink = (linkId: string) => {
+        const id = toast.loading("Deleting link...");
+        fetch(`${api.buildUrl(api.links)}/${linkId}`, {
+            method: "DELETE",
+            headers: {
+                "Content-type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("token")}`
+            }
+        }).then(res => {
+            if (res.status === 202) {
+                return res.json();
+            }
+            return Promise.reject(res);
+        }).then(() => {
+            //delete the link from the state
+            let _links = links.filter(link => link._id !== linkId);
+            setLinks(_links);
+            toast.update(id,
+                {
+                    render: "Link deleted successfully!",
+                    type: "success",
+                    isLoading: false,
+                }
+            );
+        }).catch(_ => {
+            toast.update(id,
+                {
+                    render: "Unable to delete the link!",
+                    type: "error",
+                    isLoading: false,
+                }
+            );
+        }).finally(() => {
+            setTimeout(() => {
+                toast.dismiss(id);
+            }, 5000);
+        });
+
+    }
+
     return (
         <div className="dash-page">
             <ToastContainer
@@ -81,8 +121,12 @@ export default function DashPage() {
                     <div className="links-grid">
                         {links.map((link, index) => (
                             <LinkCard key={index}
+                                id={link._id}
                                 title={link.originalUrl}
                                 subtitle={link.shortenUrl}
+                                onDelete={(id) => {
+                                    deleteLink(id);
+                                }}
                             />
                         ))}
                     </div>

--- a/frontend/src/components/DashPage.tsx
+++ b/frontend/src/components/DashPage.tsx
@@ -103,6 +103,12 @@ export default function DashPage() {
 
     }
 
+    const openShortenLink = (shortenId: string) => {
+        let shortenLink = `${api.base}/${shortenId}`;
+        console.log(shortenLink);
+        window.open(shortenLink, "_blank");
+    };
+
     return (
         <div className="dash-page">
             <ToastContainer
@@ -124,6 +130,7 @@ export default function DashPage() {
                                 id={link._id}
                                 title={link.originalUrl}
                                 subtitle={link.shortenUrl}
+                                onShorten={(shortenId) => openShortenLink(shortenId)}
                                 onDelete={(id) => {
                                     deleteLink(id);
                                 }}

--- a/frontend/src/components/DashPage.tsx
+++ b/frontend/src/components/DashPage.tsx
@@ -25,6 +25,12 @@ export default function DashPage() {
             window.location.href = "/";
         }
 
+        toast.info(
+            "Click on card to copy link to clipboard!", {
+            position: "top-right",
+            autoClose: 3000,
+        });
+
         setLoading(true);
 
         fetch(api.buildUrl(api.links), {
@@ -206,7 +212,11 @@ export default function DashPage() {
         });
     }
 
-
+    const copyLink = (shortenId: string) => {
+        let shortenLink = `${api.base}/${shortenId}`;
+        navigator.clipboard.writeText(shortenLink);
+        toast.info("Copied to clipboard!");
+    };
 
     return (
         <div className="dash-page">
@@ -272,6 +282,7 @@ export default function DashPage() {
                                 id={link._id}
                                 title={link.originalUrl}
                                 subtitle={link.shortenUrl}
+                                onCopy={(shortenId) => copyLink(shortenId)}
                                 onShorten={(shortenId) => openShortenLink(shortenId)}
                                 onEdit={(id, original, shortenId) => {
                                     openLinkEditor(id, original, shortenId);

--- a/frontend/src/components/DashPage.tsx
+++ b/frontend/src/components/DashPage.tsx
@@ -2,7 +2,11 @@ import { useContext, useEffect, useState } from "react"
 import { AuthContext } from "../containers/App"
 import { Fade, Spinner } from "reactstrap";
 import { api } from "../utils/constants";
+import { ToastContainer, toast } from 'react-toastify';
+
 import LinkCard from "./LinkCard";
+
+import 'react-toastify/dist/ReactToastify.css';
 import "./DashPage.css"
 
 interface UserLink {
@@ -35,18 +39,25 @@ export default function DashPage() {
             }
             return Promise.reject(res);
         }).then((response) => {
-            let _links: UserLink[] = [];
-            for (let i = 0; i < response.length; i++) {
-                _links.push(response[i]);
+            try {
+                if (response.length === 0) {
+                    setLoading(false);
+                    toast.info("You have no links yet. Create one now!");
+                    return
+                }
+
+                let _links: UserLink[] = [];
+                for (let i = 0; i < response.length; i++) {
+                    _links.push(response[i]);
+                }
+                setLinks(_links);
+                setLoading(false);
+            } catch (err) {
+                throw err;
             }
-            setLinks(_links);
-            setLoading(false);
         }).catch(err => {
-            console.log(err);
-            err.json().then((error: any) => {
-                console.log(error.message);
-                // setOutput(error.message);
-            });
+            // console.log(err);
+            toast.error(err.message);
             setLoading(false);
         });
 
@@ -54,6 +65,11 @@ export default function DashPage() {
 
     return (
         <div className="dash-page">
+            <ToastContainer
+                position="bottom-left"
+                newestOnTop
+                theme="colored"
+            />
             <div className="heading dash-heading">
                 <span className="tagline">Your Dashboard: Manage Your Shortened URLs</span>
                 <span className="tagline sub">Edit or delete your links anytime from your dashboard</span>

--- a/frontend/src/components/DashPage.tsx
+++ b/frontend/src/components/DashPage.tsx
@@ -1,17 +1,77 @@
-import { useContext, useEffect } from "react"
+import { useContext, useEffect, useState } from "react"
 import { AuthContext } from "../containers/App"
+import { Fade, Spinner } from "reactstrap";
+import { api } from "../utils/constants";
+import LinkCard from "./LinkCard";
+import "./DashPage.css"
+
+interface UserLink {
+    id: string,
+    shortenUrl: string,
+    originalUrl: string,
+}
 
 export default function DashPage() {
     const { isLoggedIn } = useContext(AuthContext);
+    const [links, setLinks] = useState<UserLink[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
         if (!isLoggedIn) {
             window.location.href = "/";
         }
-    }, [isLoggedIn])
+
+        setLoading(true);
+
+        fetch(api.buildUrl(api.links), {
+            method: "GET",
+            headers: {
+                "Content-type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("token")}`
+            }
+        }).then(res => {
+            if (res.ok) {
+                return res.json();
+            }
+            return Promise.reject(res);
+        }).then((response) => {
+            let _links: UserLink[] = [];
+            for (let i = 0; i < response.length; i++) {
+                _links.push(response[i]);
+            }
+            setLinks(_links);
+            setLoading(false);
+        }).catch(err => {
+            console.log(err);
+            err.json().then((error: any) => {
+                console.log(error.message);
+                // setOutput(error.message);
+            });
+            setLoading(false);
+        });
+
+    }, [isLoggedIn]);
 
     return (
         <div className="dash-page">
+            <div className="heading dash-heading">
+                <span className="tagline">Your Dashboard: Manage Your Shortened URLs</span>
+                <span className="tagline sub">Edit or delete your links anytime from your dashboard</span>
+            </div>
+            {loading ? (
+                <Spinner style={{ marginTop: "20px" }} />
+            ) : (
+                <Fade tag="div">
+                    <div className="links-grid">
+                        {links.map((link, index) => (
+                            <LinkCard key={index}
+                                title={link.originalUrl}
+                                subtitle={link.shortenUrl}
+                            />
+                        ))}
+                    </div>
+                </Fade>
+            )}
         </div>
     )
 }

--- a/frontend/src/components/HomePage.css
+++ b/frontend/src/components/HomePage.css
@@ -9,7 +9,15 @@
 
 .input-group {
     width: 55vw;
+    margin-left: 24px;
+    margin-right: 24px;
     height: 7vh;
+}
+
+@media (max-width: 850px) {
+    .input-group {
+        width: 90vw;
+    }
 }
 
 .input-field {
@@ -87,10 +95,17 @@
 
 .tagline {
     font-size: 32px;
-    margin: 0;
+    margin-left: 24px;
+    margin-right: 24px;
 }
 
 .sub {
     font-size: 16px;
     color: #909090;
+}
+
+@media (max-width: 450px) {
+    .tagline {
+        font-size: 24px;
+    }
 }

--- a/frontend/src/components/LinkCard.css
+++ b/frontend/src/components/LinkCard.css
@@ -1,0 +1,56 @@
+.link-card {
+    color: #f9fafc;
+    background-color: #202020;
+    border-radius: 16px;
+}
+
+.link-card:hover {
+    background-color: #303030;
+}
+
+.btn-icon {
+    background: none;
+    border: none;
+    color: #1b1b1b;
+    margin: 8px;
+    border-radius: 72px;
+}
+
+.btn-green {
+    background-color: #66BB6A;
+}
+
+.btn-green:hover,
+.btn-green:active,
+.btn-green:focus {
+    background-color: #64FFDA;
+}
+
+.btn-red {
+    background-color: #D32F2F;
+}
+
+.btn-red:hover,
+.btn-red:active,
+.btn-red:focus {
+    background-color: #FF5252;
+}
+
+.shorten-link {
+    color: #929ca6;
+    width: max-content;
+    background-color: #252525;
+    padding-top: 4px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-bottom: 4px;
+    border-radius: 12px;
+}
+
+.shorten-link:hover {
+    color: #929ca6;
+    width: max-content;
+    background-color: black;
+    border-radius: 24px;
+    transition: all 0.5s ease-in-out;
+}

--- a/frontend/src/components/LinkCard.css
+++ b/frontend/src/components/LinkCard.css
@@ -45,6 +45,7 @@
     padding-right: 16px;
     padding-bottom: 4px;
     border-radius: 12px;
+    cursor: pointer;
 }
 
 .shorten-link:hover {

--- a/frontend/src/components/LinkCard.tsx
+++ b/frontend/src/components/LinkCard.tsx
@@ -5,6 +5,7 @@ interface Props {
     id: string,
     title: string;
     subtitle: string;
+    onShorten: (shortenId: string) => void;
     onDelete: (linkId: string) => void;
 }
 
@@ -15,7 +16,10 @@ export default function LinkCard(props: Props) {
                 <div className="d-flex align-items-center">
                     <div className="text-truncate">
                         <CardText tag="h5" className="text-truncate">{props.title}</CardText>
-                        <CardText ctag="h6" className="mb-2 text-truncate shorten-link">
+                        <CardText
+                            ctag="h6"
+                            className="mb-2 text-truncate shorten-link"
+                            onClick={() => { props.onShorten(props.subtitle) }}>
                             {props.subtitle}
                             <i className="bi bi-box-arrow-up-right" style={{ marginLeft: "8px" }}></i>
                         </CardText>

--- a/frontend/src/components/LinkCard.tsx
+++ b/frontend/src/components/LinkCard.tsx
@@ -2,8 +2,10 @@ import { Card, CardText, CardBody, Button } from 'reactstrap';
 import './LinkCard.css';
 
 interface Props {
+    id: string,
     title: string;
     subtitle: string;
+    onDelete: (linkId: string) => void;
 }
 
 export default function LinkCard(props: Props) {
@@ -29,7 +31,11 @@ export default function LinkCard(props: Props) {
                         <Button color="success" className="btn-icon btn-green" >
                             <i className="bi bi-pencil-fill"></i>
                         </Button>
-                        <Button color="danger" className="btn-icon btn-red mt-1">
+                        <Button color="danger"
+                            className="btn-icon btn-red mt-1"
+                            onClick={() => {
+                                props.onDelete(props.id)
+                            }}>
                             <i className="bi bi-trash-fill"></i>
                         </Button>
                     </div>

--- a/frontend/src/components/LinkCard.tsx
+++ b/frontend/src/components/LinkCard.tsx
@@ -6,6 +6,7 @@ interface Props {
     title: string;
     subtitle: string;
     onShorten: (shortenId: string) => void;
+    onEdit: (id: string, originalUrl: string, shortenId: string) => void;
     onDelete: (linkId: string) => void;
 }
 
@@ -32,7 +33,12 @@ export default function LinkCard(props: Props) {
                             alignItems: "flex-end",
                             justifyContent: "center",
                         }}>
-                        <Button color="success" className="btn-icon btn-green" >
+                        <Button
+                            color="success"
+                            className="btn-icon btn-green"
+                            onClick={() => {
+                                props.onEdit(props.id, props.title, props.subtitle)
+                            }}>
                             <i className="bi bi-pencil-fill"></i>
                         </Button>
                         <Button color="danger"

--- a/frontend/src/components/LinkCard.tsx
+++ b/frontend/src/components/LinkCard.tsx
@@ -1,0 +1,40 @@
+import { Card, CardText, CardBody, Button } from 'reactstrap';
+import './LinkCard.css';
+
+interface Props {
+    title: string;
+    subtitle: string;
+}
+
+export default function LinkCard(props: Props) {
+    return (
+        <Card className="link-card">
+            <CardBody>
+                <div className="d-flex align-items-center">
+                    <div className="text-truncate">
+                        <CardText tag="h5" className="text-truncate">{props.title}</CardText>
+                        <CardText ctag="h6" className="mb-2 text-truncate shorten-link">
+                            {props.subtitle}
+                            <i className="bi bi-box-arrow-up-right" style={{ marginLeft: "8px" }}></i>
+                        </CardText>
+
+                    </div>
+                    <div className="ms-auto"
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "flex-end",
+                            justifyContent: "center",
+                        }}>
+                        <Button color="success" className="btn-icon btn-green" >
+                            <i className="bi bi-pencil-fill"></i>
+                        </Button>
+                        <Button color="danger" className="btn-icon btn-red mt-1">
+                            <i className="bi bi-trash-fill"></i>
+                        </Button>
+                    </div>
+                </div>
+            </CardBody>
+        </Card>
+    );
+};

--- a/frontend/src/components/LinkCard.tsx
+++ b/frontend/src/components/LinkCard.tsx
@@ -5,6 +5,7 @@ interface Props {
     id: string,
     title: string;
     subtitle: string;
+    onCopy: (shortenId: string) => void;
     onShorten: (shortenId: string) => void;
     onEdit: (id: string, originalUrl: string, shortenId: string) => void;
     onDelete: (linkId: string) => void;
@@ -12,7 +13,11 @@ interface Props {
 
 export default function LinkCard(props: Props) {
     return (
-        <Card className="link-card">
+        <Card
+            className="link-card"
+            onClick={() => {
+                props.onCopy(props.subtitle)
+            }}>
             <CardBody>
                 <div className="d-flex align-items-center">
                     <div className="text-truncate">

--- a/frontend/src/containers/App.tsx
+++ b/frontend/src/containers/App.tsx
@@ -6,6 +6,7 @@ import ErrorPage from '../components/ErrorPage';
 import NavBar from '../components/NavBar';
 import AuthPage from '../components/AuthPage';
 import { api } from '../utils/constants';
+import DashPage from '../components/DashPage';
 
 export const AuthContext = createContext({
   isLoggedIn: false,
@@ -45,6 +46,7 @@ export default function App() {
               <HomePage /></>
           } />
           <Route path="/auth" element={isLoggedIn ? <Navigate to="/" replace /> : <AuthPage />} />
+          <Route path="/dashboard" element={isLoggedIn ? <DashPage /> : <Navigate to="/" replace />} />
           <Route path="/not-found" element={<ErrorPage />} />
           <Route path="*" element={<ErrorPage />} />
         </Routes>


### PR DESCRIPTION
This pull request adds a new feature to the website - a dashboard page where users can view a list of links they have shortened. This provides an easy way for users to keep track of and manage their shortened links.

#### Preview
![image](https://user-images.githubusercontent.com/52543663/231970230-b39581b4-f55b-4d4e-8e9e-ff038f88d8a3.png)
